### PR TITLE
Made states left and right responsive

### DIFF
--- a/stylesheets/core/_states.scss
+++ b/stylesheets/core/_states.scss
@@ -6,9 +6,9 @@
 
 .is-active, .is-visible { display: block; }
 
-.left { float: left; }
+.left { @include breakpoint($breakpoint-10) { float: left; } }
 
-.right { float: right; }
+.right { @include breakpoint($breakpoint-10) { float: right; } }
 
 .text-left { text-align: left; }
 


### PR DESCRIPTION
When you have content generated in your document differently than displayed 
you want .left and .right to be responsive. For example:

``` html
<div class="l-one-third right">
    <h1>Table of Contents</h1>
    <p>This should normally be rendered in a column to the right
    of the main content, but when viewing on mobile be the first
    to be read</p>
</div>
<div class="l-two-third left">
    <h1>Some Article</h1>
    <p> In normal flow this should be rendered to the left, but 
    when collapsed in mobile, it should come below the table of 
    contents.</p>
</div>
```