### PR TITLE
Support Android Chrome Theme Color

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="apple-mobile-web-app-title" content="" />
+    <meta name="theme-color" content="#4fca96" />
     <meta name="msapplication-TileImage" content="windows-icon.png" />
     <meta name="msapplication-TileColor" content="#4fca96" />
 

--- a/pattern-library/index.html
+++ b/pattern-library/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="apple-mobile-web-app-title" content="" />
+    <meta name="theme-color" content="#0f7a3b" />
     <meta name="msapplication-TileImage" content="../windows-icon.png" />
     <meta name="msapplication-TileColor" content="#0f7a3b" />
 

--- a/pattern-library/shared-components.html
+++ b/pattern-library/shared-components.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="apple-mobile-web-app-title" content="" />
+    <meta name="theme-color" content="#0f7a3b" />
     <meta name="msapplication-TileImage" content="../windows-icon.png" />
     <meta name="msapplication-TileColor" content="#0f7a3b" />
 


### PR DESCRIPTION
Starting in version 39 of Chrome for Android on Lollipop, you’ll now be able to use the theme-color meta tag to set the toolbar color.